### PR TITLE
feat: add notification system

### DIFF
--- a/tei-editor/src/App.jsx
+++ b/tei-editor/src/App.jsx
@@ -1,10 +1,11 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import FileLoader from './components/FileLoader'
 import ThreePaneLayout from './components/ThreePaneLayout'
 import ExportButton from './components/ExportButton'
 import PageIndicator from './components/PageIndicator'
 import { TEIOperations } from './utils/teiOperations'
 import { extractTeiMetadata } from './utils/teiMetadata'
+import { useNotifications } from './hooks/useNotifications'
 
 function App() {
   const [teiDocument, setTeiDocument] = useState(null)
@@ -13,6 +14,7 @@ function App() {
   const [pageIndicatorProps, setPageIndicatorProps] = useState(null)
   const [documentMetadata, setDocumentMetadata] = useState(null)
   const [availableSamples, setAvailableSamples] = useState([])
+  const notify = useNotifications()
 
   // Load available samples on component mount
   useEffect(() => {
@@ -70,7 +72,7 @@ function App() {
       
       handleFileLoad(teiDocument, images)
     } catch (error) {
-      alert(`Error switching to document: ${error.message}`)
+      notify(`Error switching to document: ${error.message}`, 'error')
       console.error('Document switch failed:', error)
     }
   }
@@ -108,7 +110,7 @@ function App() {
 
   const handleTeiOperation = (operation, selectionData) => {
     if (!teiDocument) {
-      alert('No TEI document loaded')
+      notify('No TEI document loaded', 'error')
       return
     }
 
@@ -124,11 +126,11 @@ function App() {
       })
       
       // Show success message
-      alert(`✅ ${result.operation} completed successfully!`)
+      notify(`✅ ${result.operation} completed successfully!`, 'success')
       
       console.log('TEI Operation result:', result)
     } catch (error) {
-      alert(`❌ Error: ${error.message}`)
+      notify(`❌ Error: ${error.message}`, 'error')
       console.error('TEI Operation failed:', error)
     }
   }

--- a/tei-editor/src/components/Notification.jsx
+++ b/tei-editor/src/components/Notification.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+function Notification({ message, type = 'info', onClose }) {
+  const typeStyles = {
+    info: 'bg-blue-600',
+    success: 'bg-green-600',
+    error: 'bg-red-600'
+  }
+
+  return (
+    <div className={`text-white px-4 py-2 rounded shadow flex items-start gap-2 ${typeStyles[type] || typeStyles.info}`}>
+      <span className="flex-1">{message}</span>
+      {onClose && (
+        <button onClick={onClose} className="text-white font-bold">×</button>
+      )}
+    </div>
+  )
+}
+
+export default Notification

--- a/tei-editor/src/components/SamplesCard.jsx
+++ b/tei-editor/src/components/SamplesCard.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNotifications } from '../hooks/useNotifications'
 
 function SamplesCard({ onFileLoad }) {
   const [samples, setSamples] = useState([])
   const [loading, setLoading] = useState(true)
+  const notify = useNotifications()
 
   // Load available samples on component mount
   useEffect(() => {
@@ -47,9 +49,9 @@ function SamplesCard({ onFileLoad }) {
       
       onFileLoad(teiDocument, images)
     } catch (error) {
-      alert(`Error loading sample document: ${error.message}`)
+      notify(`Error loading sample document: ${error.message}`, 'error')
     }
-  }, [onFileLoad])
+  }, [onFileLoad, notify])
 
   return (
     <div className="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-lg transition-all duration-300 h-full flex flex-col">

--- a/tei-editor/src/components/ThreePaneLayout.jsx
+++ b/tei-editor/src/components/ThreePaneLayout.jsx
@@ -5,12 +5,14 @@ import TEICodePane from './TEICodePane'
 import FloatingToolbar from './FloatingToolbar'
 import { useTextSelection } from '../hooks/useTextSelection'
 import { usePageBlockScrolling } from '../hooks/usePageBlockScrolling'
+import { useNotifications } from '../hooks/useNotifications'
 
 function ThreePaneLayout({ teiDocument, documentImages, showTeiCode, onTeiOperation, onTeiChange, onPageIndicatorUpdate }) {
   const paneWidth = showTeiCode ? 'w-1/3' : 'w-1/2'
   const { selection, isSelecting, clearSelection } = useTextSelection()
   const [selectedStanzas, setSelectedStanzas] = useState([])
   const [isModifyingTei, setIsModifyingTei] = useState(false)
+  const notify = useNotifications()
   
   // Page-block synchronized scrolling
   const {
@@ -57,7 +59,7 @@ function ThreePaneLayout({ teiDocument, documentImages, showTeiCode, onTeiOperat
       // For merge operations, use checkbox selection instead of text selection
       if (operation === 'merge-stanzas') {
         if (selectedStanzas.length < 2) {
-          alert('Please select at least 2 stanzas using the checkboxes to merge them.')
+          notify('Please select at least 2 stanzas using the checkboxes to merge them.', 'info')
           return
         }
         

--- a/tei-editor/src/components/UploadCard.jsx
+++ b/tei-editor/src/components/UploadCard.jsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
+import { useNotifications } from '../hooks/useNotifications'
 
 function UploadCard({ onFileLoad }) {
+  const notify = useNotifications()
   const handleFileSelect = useCallback(async (event) => {
     const file = event.target.files[0]
     if (!file) return
@@ -33,9 +35,9 @@ function UploadCard({ onFileLoad }) {
       
       onFileLoad(teiDocument, images)
     } catch (error) {
-      alert(`Error loading TEI file: ${error.message}`)
+      notify(`Error loading TEI file: ${error.message}`, 'error')
     }
-  }, [onFileLoad])
+  }, [onFileLoad, notify])
 
   const handleDrop = useCallback((event) => {
     event.preventDefault()

--- a/tei-editor/src/hooks/useNotifications.jsx
+++ b/tei-editor/src/hooks/useNotifications.jsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, useCallback } from 'react'
+import Notification from '../components/Notification'
+
+const NotificationContext = createContext(null)
+
+export function NotificationProvider({ children }) {
+  const [notifications, setNotifications] = useState([])
+
+  const removeNotification = useCallback((id) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id))
+  }, [])
+
+  const addNotification = useCallback((message, type = 'info') => {
+    const id = Date.now() + Math.random()
+    setNotifications((prev) => [...prev, { id, message, type }])
+    setTimeout(() => removeNotification(id), 3000)
+  }, [removeNotification])
+
+  return (
+    <NotificationContext.Provider value={{ addNotification }}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {notifications.map((n) => (
+          <Notification key={n.id} message={n.message} type={n.type} onClose={() => removeNotification(n.id)} />
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  )
+}
+
+export function useNotifications() {
+  const context = useContext(NotificationContext)
+  if (!context) {
+    throw new Error('useNotifications must be used within a NotificationProvider')
+  }
+  return context.addNotification
+}

--- a/tei-editor/src/main.jsx
+++ b/tei-editor/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { NotificationProvider } from './hooks/useNotifications'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <NotificationProvider>
+      <App />
+    </NotificationProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- introduce notification component and provider hook for queued messages
- replace legacy alert calls across app with queued notifications
- wrap app with notification provider for global access

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e59ba4ef08322814acb3aed7214c9