### PR TITLE
feat: add theme tokens and unify colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,36 @@ tei-editor/
 
 ## 🎨 Design System
 
+### Palette
+
+| Token | Value |
+|-------|-------|
+| `--color-primary` | `#0f766e` |
+| `--color-primary-dark` | `#0d9488` |
+| `--color-secondary` | `#3b82f6` |
+| `--color-secondary-dark` | `#2563eb` |
+| `--color-neutral-50` | `#f9fafb` |
+| `--color-neutral-100` | `#f3f4f6` |
+| `--color-neutral-200` | `#e5e7eb` |
+| `--color-neutral-300` | `#d1d5db` |
+| `--color-neutral-400` | `#9ca3af` |
+| `--color-neutral-500` | `#6b7280` |
+| `--color-neutral-600` | `#4b5563` |
+| `--color-neutral-700` | `#374151` |
+| `--color-neutral-800` | `#1f2937` |
+| `--color-neutral-900` | `#111827` |
+
+### Type Scale
+
+| Token | Size |
+|-------|------|
+| `--font-size-sm` | `0.875rem` |
+| `--font-size-base` | `1rem` |
+| `--font-size-lg` | `1.125rem` |
+| `--font-size-xl` | `1.25rem` |
+| `--font-size-2xl` | `1.5rem` |
+| `--font-size-3xl` | `1.875rem` |
+
 ### Modern Minimalist Aesthetic
 
 - **Color Palette**: Monochromatic grays with deep teal accent (#0f766e)

--- a/tei-editor/src/components/FileLoader.jsx
+++ b/tei-editor/src/components/FileLoader.jsx
@@ -3,17 +3,17 @@ import SamplesCard from './SamplesCard'
 
 function FileLoader({ onFileLoad }) {
   return (
-    <div className="h-full w-full bg-white flex flex-col justify-center items-center px-6">
+      <div className="h-full w-full bg-white flex flex-col justify-center items-center px-6">
       {/* Header */}
-      <div className="text-center mb-12">
-        <h1 className="text-3xl font-light text-gray-900 mb-3 tracking-tight">
-          TEI Poetry Editor
-        </h1>
-        <p className="text-gray-500 font-light">
-          Load your TEI document or select a sample to get started
-        </p>
-        {/* Force refresh marker */}
-      </div>
+        <div className="text-center mb-12">
+          <h1 className="text-3xl font-semibold text-primary mb-3 tracking-tight">
+            TEI Poetry Editor
+          </h1>
+          <p className="text-base text-muted font-normal">
+            Load your TEI document or select a sample to get started
+          </p>
+          {/* Force refresh marker */}
+        </div>
 
       {/* Cards Container - Single Row */}
       <div className="flex justify-center items-center gap-8">
@@ -27,13 +27,13 @@ function FileLoader({ onFileLoad }) {
 
         {/* Optional: Add some bottom spacing or footer info */}
         <div className="mt-16 text-center">
-          <div className="inline-flex items-center space-x-6 text-sm text-gray-500">
+          <div className="inline-flex items-center space-x-6 text-sm text-muted">
             <div className="flex justify-center space-x-2">
-              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+              <div className="w-2 h-2 bg-primary rounded-full"></div>
               <span>Secure file processing</span>
             </div>
             <div className="flex justify-center space-x-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+              <div className="w-2 h-2 bg-secondary rounded-full"></div>
               <span>TEI P5 compliant</span>
             </div>
           </div>

--- a/tei-editor/src/components/UploadCard.jsx
+++ b/tei-editor/src/components/UploadCard.jsx
@@ -51,21 +51,21 @@ function UploadCard({ onFileLoad }) {
   }, [])
 
   return (
-    <div className="bg-white border border-gray-200 hover:border-teal-700 transition-all duration-200 h-full">
+    <div className="bg-white border border-neutral-200 hover:border-primary transition-all duration-200 h-full">
       {/* Card Header */}
       <div className="text-center p-8 pb-6">
         <div className="inline-flex items-center justify-center w-10 h-10 mb-6">
-          <svg className="w-6 h-6 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1}>
+          <svg className="w-6 h-6 text-neutral-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
         </div>
-        <h3 className="text-lg font-light text-gray-900 mb-3 tracking-wide">Upload File</h3>
-        <p className="text-sm text-gray-500 font-light">Upload your own TEI document</p>
+        <h3 className="text-lg font-semibold text-primary mb-3 tracking-wide">Upload File</h3>
+        <p className="text-sm text-muted font-normal">Upload your own TEI document</p>
       </div>
 
       {/* Upload Button */}
       <div className="px-8 pb-8 flex-1 flex items-center justify-center">
-        <label className="inline-flex items-center px-8 py-3 bg-teal-700 hover:bg-teal-800 text-white text-sm font-light cursor-pointer transition-colors">
+        <label className="inline-flex items-center px-8 py-3 bg-primary hover:bg-primary-dark text-white text-sm font-medium cursor-pointer transition-colors">
           <input
             type="file"
             className="hidden"
@@ -78,9 +78,9 @@ function UploadCard({ onFileLoad }) {
 
       {/* Card Footer */}
       <div className="px-8 pb-8">
-        <div className="pt-6 border-t border-gray-100">
-          <div className="flex items-center justify-center text-xs text-gray-400 font-light">
-            <div className="w-1 h-1 bg-teal-700 rounded-full mr-2"></div>
+        <div className="pt-6 border-t border-neutral-100">
+          <div className="flex items-center justify-center text-xs text-neutral-400 font-normal">
+            <div className="w-1 h-1 bg-primary rounded-full mr-2"></div>
             Supports TEI P5 XML files
           </div>
         </div>

--- a/tei-editor/src/index.css
+++ b/tei-editor/src/index.css
@@ -1,3 +1,4 @@
+@import './styles/theme.css';
 /* TEI Editor Styles - Plain CSS Implementation */
 
 * {

--- a/tei-editor/src/styles/theme.css
+++ b/tei-editor/src/styles/theme.css
@@ -1,0 +1,29 @@
+:root {
+  /* Primary colors */
+  --color-primary: #0f766e;
+  --color-primary-dark: #0d9488;
+
+  /* Secondary colors */
+  --color-secondary: #3b82f6;
+  --color-secondary-dark: #2563eb;
+
+  /* Neutral palette */
+  --color-neutral-50: #f9fafb;
+  --color-neutral-100: #f3f4f6;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-400: #9ca3af;
+  --color-neutral-500: #6b7280;
+  --color-neutral-600: #4b5563;
+  --color-neutral-700: #374151;
+  --color-neutral-800: #1f2937;
+  --color-neutral-900: #111827;
+
+  /* Typography */
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+}

--- a/tei-editor/tailwind.config.js
+++ b/tei-editor/tailwind.config.js
@@ -1,0 +1,36 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx}"] ,
+  theme: {
+    extend: {
+      colors: {
+        primary: "var(--color-primary)",
+        'primary-dark': "var(--color-primary-dark)",
+        secondary: "var(--color-secondary)",
+        'secondary-dark': "var(--color-secondary-dark)",
+        muted: "var(--color-neutral-500)",
+        neutral: {
+          50: "var(--color-neutral-50)",
+          100: "var(--color-neutral-100)",
+          200: "var(--color-neutral-200)",
+          300: "var(--color-neutral-300)",
+          400: "var(--color-neutral-400)",
+          500: "var(--color-neutral-500)",
+          600: "var(--color-neutral-600)",
+          700: "var(--color-neutral-700)",
+          800: "var(--color-neutral-800)",
+          900: "var(--color-neutral-900)",
+        }
+      },
+      fontSize: {
+        sm: "var(--font-size-sm)",
+        base: "var(--font-size-base)",
+        lg: "var(--font-size-lg)",
+        xl: "var(--font-size-xl)",
+        '2xl': "var(--font-size-2xl)",
+        '3xl': "var(--font-size-3xl)",
+      }
+    }
+  },
+  plugins: []
+}


### PR DESCRIPTION
## Summary
- add global theme.css with color and type tokens
- configure Tailwind to expose palette and font scale
- refactor FileLoader and UploadCard to use new utility classes and fonts
- document palette and typography for contributors

## Testing
- `npm test` *(fails: Error: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/..., run npx playwright install)*
- `npx playwright install chromium firefox` *(fails: server returned code 403 body 'Forbidden')*
- `npm run lint` *(fails: no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_688e5a0d06a083228a4acbfc8437bf75