### PR TITLE
feat: modernize file loader layout

### DIFF
--- a/tei-editor/src/components/FileLoader.jsx
+++ b/tei-editor/src/components/FileLoader.jsx
@@ -3,42 +3,39 @@ import SamplesCard from './SamplesCard'
 
 function FileLoader({ onFileLoad }) {
   return (
-    <div className="h-full w-full bg-white flex flex-col justify-center items-center px-6">
-      {/* Header */}
-      <div className="text-center mb-12">
-        <h1 className="text-3xl font-light text-gray-900 mb-3 tracking-tight">
+    <div className="min-h-screen w-full bg-white flex flex-col">
+      {/* Hero Header */}
+      <section className="w-full bg-gray-50 py-16 px-4 text-center">
+        <h1 className="text-4xl md:text-5xl font-light text-gray-900 mb-4">
           TEI Poetry Editor
         </h1>
-        <p className="text-gray-500 font-light">
+        <p className="text-lg text-gray-600 font-light">
           Load your TEI document or select a sample to get started
         </p>
-        {/* Force refresh marker */}
-      </div>
+      </section>
 
-      {/* Cards Container - Single Row */}
-      <div className="flex justify-center items-center gap-8">
-        <div className="w-80">
+      {/* Cards Container */}
+      <div className="flex-1 flex items-center justify-center">
+        <div className="w-full max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-8 px-6 md:px-0">
           <UploadCard onFileLoad={onFileLoad} />
-        </div>
-        <div className="w-80">
           <SamplesCard onFileLoad={onFileLoad} />
         </div>
       </div>
 
-        {/* Optional: Add some bottom spacing or footer info */}
-        <div className="mt-16 text-center">
-          <div className="inline-flex items-center space-x-6 text-sm text-gray-500">
-            <div className="flex justify-center space-x-2">
-              <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-              <span>Secure file processing</span>
-            </div>
-            <div className="flex justify-center space-x-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span>TEI P5 compliant</span>
-            </div>
+      {/* Optional: Add some bottom spacing or footer info */}
+      <div className="mt-16 text-center">
+        <div className="inline-flex items-center space-x-6 text-sm text-gray-500">
+          <div className="flex justify-center space-x-2">
+            <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+            <span>Secure file processing</span>
+          </div>
+          <div className="flex justify-center space-x-2">
+            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+            <span>TEI P5 compliant</span>
           </div>
         </div>
       </div>
+    </div>
   )
 }
 

--- a/tei-editor/src/components/SamplesCard.jsx
+++ b/tei-editor/src/components/SamplesCard.jsx
@@ -52,7 +52,7 @@ function SamplesCard({ onFileLoad }) {
   }, [onFileLoad])
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-lg transition-all duration-300 h-full flex flex-col">
+    <div className="bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 h-full flex flex-col">
       {/* Card Header */}
       <div className="text-center p-6 pb-4">
         <div className="inline-flex items-center justify-center w-12 h-12 bg-green-100 rounded-xl mb-4">

--- a/tei-editor/src/components/UploadCard.jsx
+++ b/tei-editor/src/components/UploadCard.jsx
@@ -51,7 +51,7 @@ function UploadCard({ onFileLoad }) {
   }, [])
 
   return (
-    <div className="bg-white border border-gray-200 hover:border-teal-700 transition-all duration-200 h-full">
+    <div className="bg-white border border-gray-200 rounded-lg shadow-md hover:shadow-lg hover:border-teal-700 transition-shadow duration-300 h-full">
       {/* Card Header */}
       <div className="text-center p-8 pb-6">
         <div className="inline-flex items-center justify-center w-10 h-10 mb-6">


### PR DESCRIPTION
## Summary
- refresh file loader header as full-width hero with subtext
- arrange upload and sample cards in responsive grid
- add rounded corners and shadows to cards

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npm run lint` *(fails: ESLint reported multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e5a08624c8322a9c6cd5c4faf2a43